### PR TITLE
删除使用迅雷下载到 Aria2的右键菜单

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# 此版本删除了右键菜单中的使用迅雷下载到 Aria2
+
+via [thekingofcity](https://github.com/thekingofcity/XunleiToAria2)
 
 # 迅雷远程下载已关闭,  今后将无法使用 
 [新闻报道](http://www.cnbeta.com/articles/tech/638775.htm)

--- a/js/background.js
+++ b/js/background.js
@@ -14,14 +14,6 @@ function createMenu() {
     })).then(function () {
         return new Promise(function (resolve) {
             chrome.contextMenus.create({
-                "id": "xunleitoaria2_downloadoverxunlei",
-                "title": "使用迅雷下载到 Aria2",
-                "contexts": ["link", "image", "video", "audio"]
-            }, resolve);
-        })
-    }).then(function () {
-        return new Promise(function (resolve) {
-            chrome.contextMenus.create({
                 "id": "xunleitoaria2_downloadirectly",
                 "title": "直接下载链接到 Aria2",
                 "contexts": ["link", "image", "video", "audio"]


### PR DESCRIPTION
既然用不了的话就没有必要占着地方浪费空间了